### PR TITLE
Block public access to generic.html through sidebar link

### DIFF
--- a/index.html
+++ b/index.html
@@ -170,7 +170,7 @@
 									</header>
 									<ul>
 										<li><a href="index.html">Home</a></li>
-										<li><a href="generic.html">HAckathons (Coming Soon)</a></li>
+										<li><a href="#">HAckathons (Coming Soon)</a></li>
 										<li>
 											<span class="opener">Seminars</span>
 											<ul>


### PR DESCRIPTION
Small change in sidebar ```href``` to block public access to generic.html (unedited template page)